### PR TITLE
supporting or conditions on models

### DIFF
--- a/asyncdb/version.py
+++ b/asyncdb/version.py
@@ -3,7 +3,7 @@
 __title__ = "asyncdb"
 __description__ = "Library for Asynchronous data source connections \
     Collection of asyncio drivers."
-__version__ = "2.11.9"
+__version__ = "2.11.10"
 __copyright__ = "Copyright (c) 2020-2024 Jesus Lara"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"

--- a/examples/test_model_pg.py
+++ b/examples/test_model_pg.py
@@ -78,6 +78,8 @@ async def test_model(db):
             ("SVO", "Moscow Sheremétievo", "Moscow", "Russia"),
         ]
         for air in data:
+            print(Airport)
+            print('DATA > ', air)
             airport = Airport(*air)
             result = await airport.insert()
             print('INSERT: ', result)
@@ -94,6 +96,19 @@ async def test_model(db):
         print(' == Test Many ==')
         moscow = await Airport.filter(city='Moscow')
         for airport in moscow:
+            print(airport)
+        # OR Filter:
+        print(' == FILTER BY OR ==')
+        _filter = {
+            "where": {
+                "$or": [
+                    "country = 'United States'",
+                    "country = 'Russia'"
+                ]
+            }
+        }
+        ap = await Airport.filter(**_filter)
+        for airport in ap:
             print(airport)
         # test query SELECT
         print('== Test Query SELECT =')

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
         "aiosqlite>=0.18.0",
         "looseversion==1.3.0",
         "aiofiles==24.1.0",
-        "pgvector==0.3.6",
+        "pgvector==0.4.1",
         "google-cloud-bigquery==3.30.0",
         "google-cloud-core==2.4.3",
         "google-cloud-storage>=2.17.0"


### PR DESCRIPTION
## Summary by Sourcery

Add support for logical query expressions in model drivers, enhance operators handling, streamline driver code, update dependencies, and bump version to 2.11.10.

New Features:
- Support logical query DSL (with $or, $and, $not) for model filtering via a new "where" parameter
- Enable operator-based conditions ($in, $nin, $ne, $gt, $lt, $gte, $lte, $like, $ilike, $is) in model queries

Enhancements:
- Refactor Postgres driver methods to unify schema handling, simplify return logic, and incorporate the new "where" clause support
- Improve error chaining and formatting in the Elasticsearch driver
- Streamline query building in model interface with recursive parsing and leaf condition builder

Build:
- Update pgvector dependency to version 0.4.1

Documentation:
- Extend the test_model_pg example to demonstrate OR-based filtering

Chores:
- Bump asyncdb version to 2.11.10