### PR TITLE
pinned version of cassandra-driver

### DIFF
--- a/asyncdb/version.py
+++ b/asyncdb/version.py
@@ -3,7 +3,7 @@
 __title__ = "asyncdb"
 __description__ = "Library for Asynchronous data source connections \
     Collection of asyncio drivers."
-__version__ = "2.15.3"
+__version__ = "2.15.4"
 __copyright__ = "Copyright (c) 2020-2024 Jesus Lara"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ default = [
     "pylibmc==1.6.3",
     "aiomcache==0.8.2",
     "aiosqlite>=0.18.0",
-    "cassandra-driver==3.29.2",
     "rethinkdb==2.4.10.post1",
     "influxdb==5.3.2",
     "influxdb-client[async]==1.45.0",
@@ -135,7 +134,7 @@ bigquery = [
     "google-cloud-storage>=2.17.0"
 ]
 cassandra = [
-    "cassandra-driver==3.29.2",
+    "cassandra-driver>=3.29.2",
 ]
 arangodb = [
     "networkx==3.4.2",
@@ -183,7 +182,7 @@ hazelcast = [
 ]
 scylla = [
     "scylla_driver==3.26.9",
-    "cassandra-driver==3.29.2",
+    "cassandra-driver>=3.29.2",
     "acsylla==1.0.0",
     "cqlsh==6.1.2"
 ]


### PR DESCRIPTION
## Summary by Sourcery

Relax cassandra-driver dependency pinning and bump the library version.

Enhancements:
- Increment the asyncdb package version to 2.15.4.

Build:
- Update optional dependency groups to require cassandra-driver version 3.29.2 or newer instead of an exact version pin.