### PR TITLE
fix(pgPool): fix concurrent acquire() race condition via _PoolConnection

### DIFF
--- a/asyncdb/drivers/pg.py
+++ b/asyncdb/drivers/pg.py
@@ -92,6 +92,36 @@ class pgRecord(asyncpg.Record):
         return {key: self[key] for key in self.keys()}
 
 
+class _PoolConnection:
+    """Concurrent-safe connection context manager returned by pgPool.acquire().
+
+    Each coroutine gets its own instance with its own raw_conn reference,
+    so concurrent acquire() calls never share state on the pool instance.
+
+    Usage::
+
+        async with await pool.acquire() as conn:
+            row = await conn.fetch_one(sql, *args)
+    """
+
+    __slots__ = ("_raw", "_db", "_asyncpg_pool")
+
+    def __init__(self, raw_conn, db_wrapper, asyncpg_pool):
+        self._raw = raw_conn
+        self._db = db_wrapper
+        self._asyncpg_pool = asyncpg_pool
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        try:
+            await self._asyncpg_pool.release(self._raw)
+        except Exception:  # pylint: disable=W0703
+            pass
+        return False
+
+
 class pgPool(BasePool):
     """
     pgPool.
@@ -321,12 +351,17 @@ class pgPool(BasePool):
     async def acquire(self):
         """
         Takes a connection from the pool.
+
+        Returns a :class:`_PoolConnection` context manager so each caller
+        owns its connection lifecycle independently — safe for concurrent
+        coroutines::
+
+            async with await pool.acquire() as conn:
+                row = await conn.fetch_one(sql, *args)
         """
-        db = None
-        self._connection = None
-        # Take a connection from the pool.
+        raw_conn = None
         try:
-            self._connection = await self._pool.acquire()
+            raw_conn = await self._pool.acquire()
         except TooManyConnectionsError as err:
             self._logger.error(f"Too Many Connections Error: {err}")
             raise TooManyConnections(f"Too Many Connections Error: {err}") from err
@@ -344,10 +379,11 @@ class pgPool(BasePool):
             self._logger.warning(f"Interface Warning: {err}")
         except Exception as err:  # pylint: disable=W0703
             self._logger.error(f"Unknown Error on Acquire: {err}")
-        if self._connection:
-            db = pg(pool=self)
-            db.set_connection(self._connection)
-        return db
+        if raw_conn is None:
+            return None
+        db = pg(pool=self)
+        db.set_connection(raw_conn)
+        return _PoolConnection(raw_conn, db, self._pool)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         # clean up anything you need to clean up

--- a/asyncdb/drivers/pg.py
+++ b/asyncdb/drivers/pg.py
@@ -397,8 +397,10 @@ class pgPool(BasePool):
             conn = self._connection
         else:
             conn = connection
+        if isinstance(conn, _PoolConnection):
+            conn = conn._raw
         if isinstance(conn, pg):
-            conn = connection.engine()
+            conn = conn.engine()
         if not conn:
             return True
         try:


### PR DESCRIPTION
## Problem

`pgPool.acquire()` stores the acquired raw asyncpg connection on `self._connection` — a shared attribute on the pool instance — before handing it to the caller:

```python
# current (buggy)
async def acquire(self):
    self._connection = None
    self._connection = await self._pool.acquire()   # written to self
    ...
    db.set_connection(self._connection)              # read from self
    return db
```

Under concurrent usage two coroutines interleave as follows:

```
Coroutine A:  self._connection = await self._pool.acquire()  → conn_A
Coroutine B:  self._connection = await self._pool.acquire()  → conn_B  ← overwrites!
Coroutine A:  db.set_connection(self._connection)            → gets conn_B  ← wrong!
```

Both coroutines end up sharing `conn_B`, producing:

```
InterfaceError: cannot perform operation: another operation is in progress
InterfaceError: got result for unknown protocol state 3
connection is closed
```

## Fix

Introduce `_PoolConnection` — a lightweight async context manager that owns its own `raw_conn` reference. `acquire()` now uses a local variable and returns a `_PoolConnection` instance. Each coroutine gets an isolated object with no shared state on the pool.

```python
class _PoolConnection:
    __slots__ = ("_raw", "_db", "_asyncpg_pool")

    def __init__(self, raw_conn, db_wrapper, asyncpg_pool):
        self._raw = raw_conn
        self._db = db_wrapper
        self._asyncpg_pool = asyncpg_pool

    async def __aenter__(self):
        return self._db

    async def __aexit__(self, exc_type, exc_val, exc_tb):
        try:
            await self._asyncpg_pool.release(self._raw)
        except Exception:
            pass
        return False
```

Caller usage:

```python
async with await pool.acquire() as conn:
    row = await conn.fetch_one(sql, *args)
# connection is automatically released on exit
```

## Validation

Tested in production with `flowtask`'s `PersistZoomEvent` action receiving bursts of 6+ simultaneous Zoom Phone webhook events. Before the fix: consistent `InterfaceError` on concurrent events. After the fix: all events processed cleanly with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix concurrent race condition in pgPool.acquire() by returning a per-call connection context manager instead of storing the raw connection on shared pool state.

Bug Fixes:
- Prevent concurrent pgPool.acquire() calls from sharing the same underlying asyncpg connection and causing interface errors.

Enhancements:
- Introduce a lightweight _PoolConnection async context manager to encapsulate connection lifecycle and ensure automatic release on context exit.