### PR TITLE
fix(pgPool): add _pgAcquireContext to eliminate per-coroutine race condition on acquire()

### DIFF
--- a/asyncdb/drivers/pg.py
+++ b/asyncdb/drivers/pg.py
@@ -92,6 +92,72 @@ class pgRecord(asyncpg.Record):
         return {key: self[key] for key in self.keys()}
 
 
+class _pgAcquireContext:
+    """Concurrent-safe acquire context returned by pgPool.acquire().
+
+    Mirrors asyncpg's PoolAcquireContext. Each coroutine gets its own
+    instance; _raw stored here, never on the pool. Supports three patterns:
+
+        async with pool.acquire() as conn:      # Pattern C (preferred)
+        conn = await pool.acquire()              # Pattern A (backward compat)
+        async with await pool.acquire() as conn: # Pattern B (backward compat)
+    """
+    __slots__ = ('_pgpool', '_raw', '_done')
+
+    def __init__(self, pgpool: 'pgPool') -> None:
+        self._pgpool = pgpool
+        self._raw = None
+        self._done = False
+
+    async def _do_acquire(self):
+        """Acquire raw connection and wrap in pg driver."""
+        raw = None
+        try:
+            raw = await self._pgpool._pool.acquire()
+        except TooManyConnectionsError as err:
+            self._pgpool._logger.error(f"Too Many Connections Error: {err}")
+            raise TooManyConnections(f"Too Many Connections Error: {err}") from err
+        except TimeoutError as err:
+            raise ConnectionTimeout(f"Unable to connect to database: {err}") from err
+        except ConnectionRefusedError as err:
+            raise UninitializedError(f"Unable to connect to database, connection Refused: {err}") from err
+        except ConnectionDoesNotExistError as err:
+            raise ProviderError(f"Connection Error: {err}") from err
+        except InternalClientError as err:
+            raise ProviderError(f"Internal Error: {err}") from err
+        except InterfaceError as err:
+            raise ProviderError(f"Interface Error: {err}") from err
+        except InterfaceWarning as err:
+            self._pgpool._logger.warning(f"Interface Warning: {err}")
+        except Exception as err:  # pylint: disable=W0703
+            self._pgpool._logger.error(f"Unknown Error on Acquire: {err}")
+        if raw is None:
+            return None
+        db = pg(pool=self._pgpool)
+        db.set_connection(raw)
+        self._raw = raw
+        return db
+
+    async def __aenter__(self) -> 'pg':
+        if self._raw is not None or self._done:
+            raise InterfaceError('connection already acquired')
+        return await self._do_acquire()
+
+    async def __aexit__(self, *exc) -> None:
+        self._done = True
+        raw = self._raw
+        self._raw = None
+        if raw is not None:
+            try:
+                await self._pgpool._pool.release(raw)
+            except Exception:  # pylint: disable=W0703
+                pass
+
+    def __await__(self):
+        self._done = True  # mirrors asyncpg PoolAcquireContext line 1034
+        return self._do_acquire().__await__()
+
+
 class pgPool(BasePool):
     """
     pgPool.
@@ -318,36 +384,15 @@ class pgPool(BasePool):
             self._logger.exception(f"Asyncpg Unknown Error: {ex}", stack_info=True)
             raise DriverError(f"Asyncpg Unknown Error: {ex}") from ex
 
-    async def acquire(self):
+    def acquire(self) -> '_pgAcquireContext':
+        """Return a concurrent-safe acquire context.
+
+        Supports both patterns without caller changes:
+            async with pool.acquire() as conn:   # preferred (Pattern C)
+            conn = await pool.acquire()           # backward compat (Pattern A)
+            async with await pool.acquire() as conn:  # backward compat (Pattern B)
         """
-        Takes a connection from the pool.
-        """
-        db = None
-        self._connection = None
-        # Take a connection from the pool.
-        try:
-            self._connection = await self._pool.acquire()
-        except TooManyConnectionsError as err:
-            self._logger.error(f"Too Many Connections Error: {err}")
-            raise TooManyConnections(f"Too Many Connections Error: {err}") from err
-        except TimeoutError as err:
-            raise ConnectionTimeout(f"Unable to connect to database: {err}") from err
-        except ConnectionRefusedError as err:
-            raise UninitializedError(f"Unable to connect to database, connection Refused: {err}") from err
-        except ConnectionDoesNotExistError as err:
-            raise ProviderError(f"Connection Error: {err}") from err
-        except InternalClientError as err:
-            raise ProviderError(f"Internal Error: {err}") from err
-        except InterfaceError as err:
-            raise ProviderError(f"Interface Error: {err}") from err
-        except InterfaceWarning as err:
-            self._logger.warning(f"Interface Warning: {err}")
-        except Exception as err:  # pylint: disable=W0703
-            self._logger.error(f"Unknown Error on Acquire: {err}")
-        if self._connection:
-            db = pg(pool=self)
-            db.set_connection(self._connection)
-        return db
+        return _pgAcquireContext(self)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         # clean up anything you need to clean up
@@ -362,7 +407,7 @@ class pgPool(BasePool):
         else:
             conn = connection
         if isinstance(conn, pg):
-            conn = connection.engine()
+            conn = conn.engine()
         if not conn:
             return True
         try:

--- a/tests/test_pgpool_concurrent_acquire.py
+++ b/tests/test_pgpool_concurrent_acquire.py
@@ -1,0 +1,220 @@
+"""Tests for _pgAcquireContext and pgPool.acquire() concurrent-acquire fix.
+
+These are integration tests that require a live PostgreSQL instance.
+Set TEST_DSN environment variable or ensure the default DSN is reachable.
+
+Run with:
+    pytest tests/test_pgpool_concurrent_acquire.py -v
+"""
+import asyncio
+import os
+
+import pytest
+import pytest_asyncio
+
+from asyncdb import AsyncPool
+from asyncdb.drivers.pg import _pgAcquireContext
+
+# ---------------------------------------------------------------------------
+# Test configuration
+# ---------------------------------------------------------------------------
+
+DRIVER = "pg"
+DSN = os.getenv(
+    "TEST_DSN",
+    "postgres://troc_pgdata:12345678@127.0.0.1:5432/navigator",
+)
+
+# Pool settings that give enough room for the concurrency tests.
+POOL_MIN = 2
+POOL_MAX = 15
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def pool():
+    """Create a connected pgPool and tear it down after each test."""
+    args = {
+        "timeout": 30,
+        "server_settings": {
+            "application_name": "TestPgAcquireContext",
+        },
+    }
+    p = AsyncPool(DRIVER, dsn=DSN, min_size=POOL_MIN, max_size=POOL_MAX, **args)
+    await p.connect()
+    yield p
+    await p.wait_close(gracefully=True, timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestPgAcquireContextConcurrency:
+    """Validate that concurrent callers each receive a distinct connection."""
+
+    async def test_concurrent_acquire_distinct_connections(self, pool):
+        """10 concurrent acquire() calls each get a distinct connection object.
+
+        Each coroutine holds its connection for 50 ms so all 10 overlap.
+        The set of id() values must have exactly 10 members, proving that no
+        two coroutines shared the same object.
+        """
+        connection_ids = []
+
+        async def grab():
+            async with pool.acquire() as conn:
+                connection_ids.append(id(conn))
+                await asyncio.sleep(0.05)  # hold long enough for overlap
+
+        await asyncio.gather(*[grab() for _ in range(10)])
+
+        assert len(connection_ids) == 10, "Expected 10 acquire results"
+        assert len(set(connection_ids)) == 10, (
+            "Each coroutine must receive a distinct connection object; "
+            f"got {len(set(connection_ids))} distinct IDs out of 10"
+        )
+
+
+class TestPatternA:
+    """Pattern A: conn = await pool.acquire()"""
+
+    async def test_pattern_a_returns_pg_wrapper(self, pool):
+        """await pool.acquire() returns a pg wrapper that can execute queries."""
+        conn = await pool.acquire()
+        assert conn is not None, "acquire() must return a non-None pg wrapper"
+        row = await conn.fetchrow("SELECT 1 AS n")
+        assert row["n"] == 1, "Expected query result n=1"
+        await pool.release(conn)
+
+    async def test_pattern_a_returns_awaitable(self, pool):
+        """pool.acquire() returns a _pgAcquireContext before being awaited."""
+        ctx = pool.acquire()
+        assert isinstance(ctx, _pgAcquireContext), (
+            "pool.acquire() must return a _pgAcquireContext, "
+            f"got {type(ctx)}"
+        )
+        # Now consume it so the fixture teardown does not see a leaked connection.
+        conn = await ctx
+        await pool.release(conn)
+
+
+class TestPatternB:
+    """Pattern B: async with await pool.acquire() as conn: ..."""
+
+    async def test_pattern_b_cm_with_await(self, pool):
+        """async with await pool.acquire() as conn: works and can run a query."""
+        async with await pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT 2 AS n")
+            assert row["n"] == 2, "Expected query result n=2"
+
+    async def test_pattern_b_conn_is_pg_wrapper(self, pool):
+        """conn inside 'async with await pool.acquire() as conn' is the pg wrapper."""
+        from asyncdb.drivers.pg import pg as PgDriver
+        async with await pool.acquire() as conn:
+            assert isinstance(conn, PgDriver), (
+                f"Expected pg wrapper, got {type(conn)}"
+            )
+
+
+class TestPatternC:
+    """Pattern C: async with pool.acquire() as conn: ... (preferred)"""
+
+    async def test_pattern_c_cm_no_await(self, pool):
+        """async with pool.acquire() as conn: works without explicit await."""
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT 3 AS n")
+            assert row["n"] == 3, "Expected query result n=3"
+
+    async def test_pattern_c_conn_is_pg_wrapper(self, pool):
+        """conn inside 'async with pool.acquire() as conn' is the pg wrapper."""
+        from asyncdb.drivers.pg import pg as PgDriver
+        async with pool.acquire() as conn:
+            assert isinstance(conn, PgDriver), (
+                f"Expected pg wrapper, got {type(conn)}"
+            )
+
+
+class TestConnectionRelease:
+    """Validate that connections are returned to the pool after CM exit."""
+
+    async def test_connection_released_after_cm_exit(self, pool):
+        """Pool remains functional after a Pattern-C context manager exits.
+
+        If the connection were not released, a second acquire on a saturated
+        pool would time-out.  With proper release it must succeed immediately.
+        """
+        async with pool.acquire() as _:
+            pass  # connection is acquired then released
+
+        # Must be able to acquire again right away.
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT 1 AS n")
+            assert row["n"] == 1
+
+    async def test_sequential_acquires_do_not_exhaust_pool(self, pool):
+        """Repeated sequential acquires must all succeed without leak."""
+        for i in range(5):
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow("SELECT $1::int AS n", i)
+                assert row["n"] == i
+
+
+class TestDoneFlagBehavior:
+    """Validate _done flag semantics on _pgAcquireContext."""
+
+    async def test_done_flag_set_after_await(self, pool):
+        """After await-ing a _pgAcquireContext the _done flag must be True.
+
+        This mirrors asyncpg's PoolAcquireContext behaviour: once a context
+        has been used as an awaitable it is considered consumed.
+        """
+        ctx = pool.acquire()
+        assert ctx._done is False, "_done must start as False"
+        conn = await ctx  # triggers __await__ which sets _done=True
+        assert ctx._done is True, "_done must be True after await"
+        await pool.release(conn)
+
+    async def test_done_flag_set_after_cm_exit(self, pool):
+        """After a CM exit the _done flag must be True."""
+        ctx = pool.acquire()
+        assert ctx._done is False
+        async with ctx as _:
+            pass
+        assert ctx._done is True, "_done must be True after __aexit__"
+
+    async def test_done_flag_prevents_cm_reuse_after_await(self, pool):
+        """A context already consumed via await cannot be used as a CM.
+
+        __aenter__ checks _done and raises InterfaceError (asyncpg.InterfaceError)
+        when _done is True.
+        """
+        from asyncpg.exceptions import InterfaceError
+        ctx = pool.acquire()
+        conn = await ctx  # sets _done=True
+        try:
+            with pytest.raises(InterfaceError):
+                async with ctx as _:
+                    pass  # must not reach here
+        finally:
+            # Release the connection acquired during the first await.
+            await pool.release(conn)
+
+    async def test_done_flag_prevents_cm_reuse_after_cm_exit(self, pool):
+        """A context already used as a CM cannot be reused.
+
+        After __aexit__ sets _done=True, a second __aenter__ call must raise.
+        """
+        from asyncpg.exceptions import InterfaceError
+        ctx = pool.acquire()
+        async with ctx:
+            pass  # first use — __aexit__ sets _done=True
+
+        with pytest.raises(InterfaceError):
+            async with ctx as _:
+                pass  # second use — must raise


### PR DESCRIPTION
## Summary

- Adds `_pgAcquireContext` class that mirrors asyncpg's `PoolAcquireContext` pattern
- Changes `pgPool.acquire()` from `async def` (returning a connection) to a regular `def` (returning a context object)
- Fixes a race condition where concurrent coroutines sharing the same pool instance would overwrite each other's connection via the shared `self._connection` attribute

## Root Cause

`pgPool.acquire()` was an `async def` that stored the acquired connection in `self._connection` — a shared instance attribute. Under concurrent load, coroutine A would acquire a connection, store it in `self._connection`, then coroutine B would acquire a different connection and overwrite `self._connection`, causing coroutine A to use B's connection or lose its reference entirely.

## Solution

Each call to `pool.acquire()` now returns a `_pgAcquireContext` instance that stores its connection in `_raw` — a local attribute on the context object, not on the pool. This is the same isolation model used by asyncpg's `PoolAcquireContext`.

## Three supported call patterns

**Pattern A** — direct await:
```python
conn = await pool.acquire()
row = await conn.fetch_one(sql)
```

**Pattern B** — await then async with:
```python
conn = await pool.acquire()
async with conn:
    row = await conn.fetch_one(sql)
```

**Pattern C** — async with directly (recommended):
```python
async with pool.acquire() as conn:
    row = await conn.fetch_one(sql)
```

## Changes

- `asyncdb/drivers/pg.py`: adds `_pgAcquireContext` class; changes `pgPool.acquire()` to `def`; fixes a typo in `release()` (`conn = connection.engine()` → `conn = conn.engine()`)
- `tests/test_pgpool_concurrent_acquire.py`: 13 tests covering concurrency isolation, all three call patterns, connection release, and done-flag guard

## Test plan

- [x] `pytest tests/test_pgpool_concurrent_acquire.py` — 13 tests passing
- [x] Live validation: burst of 6+ simultaneous Zoom webhook events processed without DB errors via navigator-dataintegrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make pgPool.acquire() concurrency-safe by returning a dedicated acquire context object instead of storing connections on the pool instance, and add integration tests to validate concurrent usage and supported call patterns.

Bug Fixes:
- Resolve a race condition where concurrent coroutines using the same pgPool instance could overwrite each other’s acquired connection via a shared pool attribute.
- Correct the connection extraction in pgPool.release() so it uses conn.engine() on pg wrapper instances.

Enhancements:
- Introduce a _pgAcquireContext helper class that mirrors asyncpg’s PoolAcquireContext and supports using pgPool.acquire() both as an awaitable and as an async context manager.

Tests:
- Add integration tests for _pgAcquireContext and pgPool.acquire() covering concurrent acquires, all supported usage patterns, connection release behavior, and done-flag semantics.