### PR TITLE
fix on ssl pg driver

### DIFF
--- a/asyncdb/drivers/pg.py
+++ b/asyncdb/drivers/pg.py
@@ -62,6 +62,45 @@ from .sql import SQLCursor, SQLDriver
 max_cached_statement_lifetime = 600
 max_cacheable_statement_size = 1024 * 15
 
+# Valid libpq sslmode values accepted by asyncpg (see SSLMode enum).
+VALID_SSLMODES = (
+    "disable",
+    "allow",
+    "prefer",
+    "require",
+    "verify-ca",
+    "verify-full",
+)
+
+
+def _resolve_sslmode(value: Optional[str]) -> Optional[str]:
+    """Normalize and validate a libpq ``sslmode`` value.
+
+    Falls back to the ``PGSSLMODE`` environment variable when no explicit
+    value is provided.
+
+    Args:
+        value: Explicit sslmode passed to the driver (e.g. ``"require"``),
+            or ``None`` to fall back to the environment.
+
+    Returns:
+        A lowercase, validated sslmode string, or ``None`` when neither an
+        explicit value nor ``PGSSLMODE`` is set.
+
+    Raises:
+        ValueError: If the resolved sslmode is not a valid libpq value.
+    """
+    if value is None:
+        value = os.environ.get("PGSSLMODE")
+    if value is None:
+        return None
+    mode = str(value).strip().lower()
+    if mode not in VALID_SSLMODES:
+        raise ValueError(
+            f"Invalid sslmode '{value}'. Must be one of: {', '.join(VALID_SSLMODES)}"
+        )
+    return mode
+
 
 class NAVConnection(asyncpg.Connection):
     """
@@ -206,6 +245,15 @@ class pgPool(BasePool):
         self._encoder = DefaultEncoder()
         ### SSL Support:
         self.ssl: bool = False
+        # Explicit libpq sslmode (e.g. "disable", "require", "verify-full").
+        # Takes effect only when a full SSL context is not configured; falls
+        # back to the PGSSLMODE environment variable when not provided.
+        _sslmode = None
+        if params and "sslmode" in params:
+            _sslmode = params.pop("sslmode")
+        elif "sslmode" in kwargs:
+            _sslmode = kwargs.pop("sslmode")
+        self._sslmode: Optional[str] = _resolve_sslmode(_sslmode)
         if params and "ssl" in params:
             ssloptions = params["ssl"]
         elif "ssl" in kwargs:
@@ -338,8 +386,16 @@ class pgPool(BasePool):
                 custom_class = {"record_class": self._record_class_}
             if self.ssl:
                 _ssl = {"ssl": self.sslctx}
+            elif self._sslmode:
+                # Explicit libpq sslmode (or PGSSLMODE). asyncpg parses the
+                # string and applies the matching SSL behavior.
+                _ssl = {"ssl": self._sslmode}
             else:
-                _ssl = {}
+                # Pass ssl=False explicitly so asyncpg does not fall back to
+                # its default sslmode='prefer' for TCP connections, which would
+                # probe ~/.postgresql/postgresql.key and may raise a
+                # PermissionError when HOME points to an unreadable directory.
+                _ssl = {"ssl": False}
             self._pool = await asyncpg.create_pool(
                 dsn=self._dsn,
                 max_queries=self._max_queries,
@@ -550,6 +606,15 @@ class pg(SQLDriver, DBCursorBackend, ModelBackend):
             self._connection_config = {}
         ### SSL Support:
         self.ssl: bool = False
+        # Explicit libpq sslmode (e.g. "disable", "require", "verify-full").
+        # Takes effect only when a full SSL context is not configured; falls
+        # back to the PGSSLMODE environment variable when not provided.
+        _sslmode = None
+        if params and "sslmode" in params:
+            _sslmode = params.pop("sslmode")
+        elif "sslmode" in kwargs:
+            _sslmode = kwargs.pop("sslmode")
+        self._sslmode: Optional[str] = _resolve_sslmode(_sslmode)
         if params and "ssl" in params:
             ssloptions = params.pop("ssl")
         elif "ssl" in kwargs:
@@ -688,7 +753,17 @@ class pg(SQLDriver, DBCursorBackend, ModelBackend):
             "max_parallel_workers": "512",
         }
         server_settings = {**server_settings, **self._server_settings}
-        _ssl = {"ssl": self.sslctx} if self.ssl else {}
+        # Resolve SSL config: full context wins, then explicit sslmode/PGSSLMODE,
+        # otherwise ssl=False so asyncpg does not fall back to its default
+        # sslmode='prefer' for TCP connections, which would probe
+        # ~/.postgresql/postgresql.key and may raise a PermissionError when HOME
+        # points to an unreadable directory.
+        if self.ssl:
+            _ssl = {"ssl": self.sslctx}
+        elif self._sslmode:
+            _ssl = {"ssl": self._sslmode}
+        else:
+            _ssl = {"ssl": False}
         custom_class = {}
         if self._custom_record:
             custom_class = {"record_class": self._record_class_}

--- a/asyncdb/version.py
+++ b/asyncdb/version.py
@@ -3,7 +3,7 @@
 __title__ = "asyncdb"
 __description__ = "Library for Asynchronous data source connections \
     Collection of asyncio drivers."
-__version__ = "2.15.7"
+__version__ = "2.15.8"
 __copyright__ = "Copyright (c) 2020-2024 Jesus Lara"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"

--- a/tests/test_pg_sslmode.py
+++ b/tests/test_pg_sslmode.py
@@ -1,0 +1,185 @@
+"""Unit tests for the explicit ``sslmode`` / ``PGSSLMODE`` support in the pg driver.
+
+These tests do NOT require a live PostgreSQL instance: the asyncpg connection
+entrypoints are mocked so we can assert how the driver resolves the ``ssl``
+keyword passed down to asyncpg.
+
+Run with:
+    pytest tests/test_pg_sslmode.py -v
+"""
+import ssl as ssl_module
+
+import pytest
+
+from asyncdb.drivers.pg import (
+    pg,
+    pgPool,
+    _resolve_sslmode,
+    VALID_SSLMODES,
+)
+
+PARAMS = {
+    "host": "localhost",
+    "port": 5432,
+    "user": "troc_pgdata",
+    "password": "12345678",
+    "database": "postgres",
+}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_sslmode helper
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSSLMode:
+    """Validation/normalization of libpq sslmode values."""
+
+    @pytest.mark.parametrize("mode", VALID_SSLMODES)
+    def test_valid_modes_pass_through(self, mode, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        assert _resolve_sslmode(mode) == mode
+
+    def test_normalizes_case_and_whitespace(self, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        assert _resolve_sslmode("  REQUIRE ") == "require"
+        assert _resolve_sslmode("Verify-Full") == "verify-full"
+
+    def test_none_without_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        assert _resolve_sslmode(None) is None
+
+    def test_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("PGSSLMODE", "verify-full")
+        assert _resolve_sslmode(None) == "verify-full"
+
+    def test_explicit_value_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("PGSSLMODE", "disable")
+        assert _resolve_sslmode("require") == "require"
+
+    def test_invalid_mode_raises(self, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        with pytest.raises(ValueError) as exc:
+            _resolve_sslmode("bogus")
+        assert "Invalid sslmode" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# __init__ parsing of sslmode (both classes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", [pg, pgPool])
+class TestSSLModeInit:
+    """Both pg and pgPool parse the sslmode option consistently."""
+
+    def test_explicit_sslmode_param(self, cls, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        obj = cls(params=dict(PARAMS), sslmode="require")
+        assert obj._sslmode == "require"
+        assert obj.ssl is False
+
+    def test_default_is_none(self, cls, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        obj = cls(params=dict(PARAMS))
+        assert obj._sslmode is None
+        assert obj.ssl is False
+
+    def test_env_var_picked_up(self, cls, monkeypatch):
+        monkeypatch.setenv("PGSSLMODE", "prefer")
+        obj = cls(params=dict(PARAMS))
+        assert obj._sslmode == "prefer"
+
+    def test_invalid_sslmode_raises_on_init(self, cls, monkeypatch):
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        with pytest.raises(ValueError):
+            cls(params=dict(PARAMS), sslmode="nope")
+
+
+# ---------------------------------------------------------------------------
+# ssl keyword resolution priority (mocking asyncpg)
+# ---------------------------------------------------------------------------
+
+
+class _FakePool:
+    """Minimal stand-in for an asyncpg pool object."""
+
+
+@pytest.mark.asyncio
+class TestPoolSSLKwarg:
+    """pgPool.connect passes the right ``ssl`` value to asyncpg.create_pool."""
+
+    async def _capture_create_pool(self, monkeypatch, **init_kwargs):
+        captured = {}
+
+        async def fake_create_pool(*args, **kwargs):
+            captured.update(kwargs)
+            return _FakePool()
+
+        monkeypatch.setattr(
+            "asyncdb.drivers.pg.asyncpg.create_pool", fake_create_pool
+        )
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        obj = pgPool(params=dict(PARAMS), **init_kwargs)
+        await obj.connect()
+        return captured
+
+    async def test_default_passes_ssl_false(self, monkeypatch):
+        captured = await self._capture_create_pool(monkeypatch)
+        assert captured["ssl"] is False
+
+    async def test_explicit_sslmode_string(self, monkeypatch):
+        captured = await self._capture_create_pool(monkeypatch, sslmode="disable")
+        assert captured["ssl"] == "disable"
+
+    async def test_env_sslmode_string(self, monkeypatch):
+        monkeypatch.setenv("PGSSLMODE", "prefer")
+
+        captured = {}
+
+        async def fake_create_pool(*args, **kwargs):
+            captured.update(kwargs)
+            return _FakePool()
+
+        monkeypatch.setattr(
+            "asyncdb.drivers.pg.asyncpg.create_pool", fake_create_pool
+        )
+        obj = pgPool(params=dict(PARAMS))
+        await obj.connect()
+        assert captured["ssl"] == "prefer"
+
+    async def test_ssl_context_takes_precedence(self, monkeypatch):
+        # A full SSL context (self.ssl=True) must win over sslmode.
+        captured = await self._capture_create_pool(
+            monkeypatch,
+            sslmode="disable",
+            ssl={"check_hostname": False},
+        )
+        assert isinstance(captured["ssl"], ssl_module.SSLContext)
+
+
+@pytest.mark.asyncio
+class TestSingleConnSSLKwarg:
+    """pg.connection passes the right ``ssl`` value to asyncpg.connect."""
+
+    async def _capture_connect(self, monkeypatch, **init_kwargs):
+        captured = {}
+
+        async def fake_connect(*args, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError("stop-after-capture")
+
+        monkeypatch.setattr("asyncdb.drivers.pg.asyncpg.connect", fake_connect)
+        monkeypatch.delenv("PGSSLMODE", raising=False)
+        obj = pg(params=dict(PARAMS), **init_kwargs)
+        with pytest.raises(Exception):
+            await obj.connection()
+        return captured
+
+    async def test_default_passes_ssl_false(self, monkeypatch):
+        captured = await self._capture_connect(monkeypatch)
+        assert captured["ssl"] is False
+
+    async def test_explicit_sslmode_string(self, monkeypatch):
+        captured = await self._capture_connect(monkeypatch, sslmode="require")
+        assert captured["ssl"] == "require"


### PR DESCRIPTION
## Summary by Sourcery

Add explicit sslmode handling for the PostgreSQL async driver to avoid unintended asyncpg SSL defaults and environment-related permission errors.

New Features:
- Support configuring PostgreSQL sslmode explicitly via driver parameters or the PGSSLMODE environment variable with validation against allowed libpq values.

Bug Fixes:
- Ensure asyncpg connections and pools pass ssl=False by default to prevent fallback to sslmode='prefer' and related filesystem permission errors when SSL is not configured.

Enhancements:
- Unify SSL configuration precedence so that an explicit SSL context overrides sslmode for both single connections and pools.

Tests:
- Add comprehensive unit tests for sslmode resolution, environment-variable fallback, initialization behavior, and ssl argument propagation to asyncpg for both pg and pgPool drivers.