### PR TITLE
fix: unbreak Windows wheel build and bump python-datamodel floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,28 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_SKIP: "pp* *-win32 *i686 *musllinux*"
           CIBW_PRERELEASE_PYTHONS: "0"
-          # Fail the build if a wheel is ever produced without the compiled
-          # Cython extension (asyncdb/utils/types.*.so / .pyd). This prevents
-          # publishing a broken wheel that raises "No module named
-          # 'asyncdb.utils.types'" at import time.
-          CIBW_TEST_COMMAND: >-
-            python -c "import glob, os, sysconfig;
-            d = os.path.join(sysconfig.get_paths()['platlib'], 'asyncdb', 'utils');
-            ext = glob.glob(os.path.join(d, 'types.*.so')) + glob.glob(os.path.join(d, 'types.*.pyd'));
-            assert ext, 'compiled Cython extension missing in ' + d;
-            print('compiled Cython extension present:', ext[0])"
         run: |
           cibuildwheel --output-dir dist
+
+      # Fail the build if any wheel is produced without the compiled Cython
+      # extension (asyncdb/utils/types.*.so / .pyd). This prevents publishing a
+      # broken wheel that raises "No module named 'asyncdb.utils.types'" at
+      # import time. We inspect the wheel archive directly instead of using
+      # CIBW_TEST_COMMAND so we never pip-install the wheel's dependencies
+      # (e.g. uvloop, which has no Windows support) just to run this check.
+      - name: Verify compiled Cython extension is present in wheels
+        shell: python
+        run: |
+          import glob, zipfile
+          wheels = glob.glob("dist/*.whl")
+          assert wheels, "no wheels were produced in dist/"
+          for whl in wheels:
+              names = zipfile.ZipFile(whl).namelist()
+              ext = [n for n in names
+                     if n.startswith("asyncdb/utils/types.")
+                     and (n.endswith(".so") or n.endswith(".pyd"))]
+              assert ext, f"compiled Cython extension missing in {whl}"
+              print(f"OK {whl}: {ext[0]}")
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "iso8601==2.1.0",
     "python-magic==0.4.27",
     "dateparser==1.1.8",
-    "python-datamodel>=0.7.0",
+    "python-datamodel>=0.10.21",
     "aiosqlite>=0.18.0",
     "looseversion==1.3.0",
     "aiofiles==24.1.0",


### PR DESCRIPTION
The CIBW_TEST_COMMAND added recently made cibuildwheel pip-install the built wheel (with all deps) in a test venv on Windows, which pulled in uvloop transitively via python-datamodel and failed: uvloop has no Windows support.

Verify the compiled Cython extension by inspecting the wheel archive directly instead of installing it, so dependencies are never resolved just to run the check. Bump the python-datamodel floor to >=0.10.21, the release that marks uvloop as non-Windows-only.

## Summary by Sourcery

Ensure built wheels contain the compiled Cython extension without installing them and update a core dependency version floor.

Bug Fixes:
- Avoid Windows wheel build failures by verifying the compiled Cython extension directly from wheel files instead of installing them via cibuildwheel test commands.

Enhancements:
- Add a release workflow step that inspects produced wheel archives to confirm the asyncdb Cython extension is present before uploading artifacts.

Build:
- Increase the python-datamodel dependency minimum version to 0.10.21 to align with updated platform support.