### PR TITLE
feat(windows-compatibility): FEAT-5 — Windows Compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,24 +35,54 @@ jobs:
           cibuildwheel --output-dir dist
 
       # Fail the build if any wheel is produced without the compiled Cython
-      # extension (asyncdb/utils/types.*.so / .pyd). This prevents publishing a
-      # broken wheel that raises "No module named 'asyncdb.utils.types'" at
-      # import time. We inspect the wheel archive directly instead of using
+      # extension (asyncdb/utils/types.*.so / .pyd), with the wrong platform
+      # tag, or missing a requested CPython ABI on Windows. This prevents
+      # publishing a broken wheel that raises "No module named
+      # 'asyncdb.utils.types'" at import time, or a Windows wheel that was
+      # not actually built for win_amd64 / the full supported CPython range.
+      # We inspect the wheel archive directly instead of using
       # CIBW_TEST_COMMAND so we never pip-install the wheel's dependencies
       # (e.g. uvloop, which has no Windows support) just to run this check.
-      - name: Verify compiled Cython extension is present in wheels
+      - name: Verify wheel tags and compiled Cython extension
         shell: python
         run: |
-          import glob, zipfile
+          import glob, sys, zipfile
+
+          EXPECTED_WINDOWS_CPYTHON_TAGS = {"cp310", "cp311", "cp312", "cp313", "cp314"}
+
           wheels = glob.glob("dist/*.whl")
           assert wheels, "no wheels were produced in dist/"
+
+          is_windows = sys.platform.startswith("win")
+          found_cpython_tags = set()
+
           for whl in wheels:
+              filename = whl.replace("\\", "/").rsplit("/", 1)[-1]
+              # Wheel filename: {name}-{version}-{python_tag}-{abi_tag}-{platform_tag}.whl
+              python_tag, _abi_tag, platform_tag = filename[:-4].split("-")[-3:]
+              found_cpython_tags.add(python_tag)
+
+              if is_windows:
+                  assert platform_tag.startswith("win_amd64"), (
+                      f"unexpected platform tag for Windows wheel {whl}: {platform_tag}"
+                  )
+                  expected_suffix = ".pyd"
+              else:
+                  assert not platform_tag.startswith("win"), (
+                      f"unexpected Windows platform tag on non-Windows runner: {whl}"
+                  )
+                  expected_suffix = ".so"
+
               names = zipfile.ZipFile(whl).namelist()
               ext = [n for n in names
                      if n.startswith("asyncdb/utils/types.")
-                     and (n.endswith(".so") or n.endswith(".pyd"))]
-              assert ext, f"compiled Cython extension missing in {whl}"
-              print(f"OK {whl}: {ext[0]}")
+                     and n.endswith(expected_suffix)]
+              assert ext, f"compiled Cython extension ({expected_suffix}) missing in {whl}"
+              print(f"OK {whl}: {ext[0]} [{python_tag}-{platform_tag}]")
+
+          if is_windows:
+              missing = EXPECTED_WINDOWS_CPYTHON_TAGS - found_cpython_tags
+              assert not missing, f"Windows wheels missing for CPython tags: {sorted(missing)}"
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ Currently AsyncDB supports the following databases:
 * Oracle (requires oracledb)
 * Redpanda (Kafka-compatible, requires aiokafka)
 
+### Platform Support ###
+
+AsyncDB's core package (`pip install asyncdb`) and the `default` extra
+(`pip install asyncdb[default]`) are supported on Linux, macOS, and Windows
+for Python 3.10–3.14. `uvloop` remains an optional performance extra
+(`pip install asyncdb[uvloop]`): it is only available on POSIX platforms and
+is never required to import or run AsyncDB. On Windows, `uvloop` activation
+is automatically and safely skipped, and the standard asyncio event loop
+policy is used instead.
+
+The `default` extra covers SQLite (`aiosqlite`), RethinkDB, InfluxDB, Redis,
+MS SQL Server (`pymssql`), Delta Lake, and DuckDB, in addition to the
+PostgreSQL support (`asyncpg`) that ships with the core package.
+
+Other provider extras (Cassandra, ScyllaDB, MySQL/MySQLdb, ODBC, Oracle,
+JDBC, ClickHouse, etc.) depend on native or platform-sensitive client
+libraries and are not guaranteed to be installable or fully supported on
+every platform, including Windows. Selecting a driver whose optional
+dependency is not installed raises a focused error naming the provider and
+the extra required to install it (e.g. `pip install asyncdb[mysql]`).
+
 ### Quick Tutorial ###
 
 ```python

--- a/asyncdb/connections.py
+++ b/asyncdb/connections.py
@@ -7,6 +7,12 @@ from .utils import install_uvloop
 
 
 T_aobj = TypeVar("T_aobj", bound="asyncdb")
+
+# Activate uvloop automatically when it is installed and the current
+# platform supports it (POSIX only). `install_uvloop()` is guaranteed to
+# never raise, so this import-time call is safe on every platform,
+# including Windows, where it is a no-op and the standard asyncio event
+# loop policy remains active.
 install_uvloop()
 
 

--- a/asyncdb/drivers/cassandra.py
+++ b/asyncdb/drivers/cassandra.py
@@ -11,30 +11,38 @@ import asyncio
 from typing import Any, Union
 from ssl import PROTOCOL_TLSv1
 import pandas as pd
-from cassandra import ReadTimeout
-from cassandra.cluster import Cluster, EXEC_PROFILE_DEFAULT, ExecutionProfile, NoHostAvailable, ResultSet
-from cassandra.io.asyncorereactor import AsyncoreConnection
-from cassandra.io.asyncioreactor import AsyncioConnection
-
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.policies import (
-    DCAwareRoundRobinPolicy,
-    WhiteListRoundRobinPolicy,
-    DowngradingConsistencyRetryPolicy,
-    # RetryPolicy
-)
-from cassandra.query import (
-    dict_factory,
-    ordered_dict_factory,
-    named_tuple_factory,
-    ConsistencyLevel,
-    PreparedStatement,
-    BatchStatement,
-    SimpleStatement,
-    BatchType,
-)
-from asyncdb.meta import Recordset
 from asyncdb.exceptions import NoDataFound, DriverError
+
+try:
+    from cassandra import ReadTimeout
+    from cassandra.cluster import Cluster, EXEC_PROFILE_DEFAULT, ExecutionProfile, NoHostAvailable, ResultSet
+    from cassandra.io.asyncorereactor import AsyncoreConnection
+    from cassandra.io.asyncioreactor import AsyncioConnection
+
+    from cassandra.auth import PlainTextAuthProvider
+    from cassandra.policies import (
+        DCAwareRoundRobinPolicy,
+        WhiteListRoundRobinPolicy,
+        DowngradingConsistencyRetryPolicy,
+        # RetryPolicy
+    )
+    from cassandra.query import (
+        dict_factory,
+        ordered_dict_factory,
+        named_tuple_factory,
+        ConsistencyLevel,
+        PreparedStatement,
+        BatchStatement,
+        SimpleStatement,
+        BatchType,
+    )
+except ImportError as _import_err:
+    raise DriverError(
+        "Cassandra driver requires 'cassandra-driver'. "
+        "Install with: pip install asyncdb[cassandra]"
+    ) from _import_err
+
+from asyncdb.meta import Recordset
 from .base import InitDriver
 
 

--- a/asyncdb/drivers/mssql.py
+++ b/asyncdb/drivers/mssql.py
@@ -5,11 +5,18 @@ import time
 import logging
 from typing import Union, Optional, Any
 from collections.abc import Iterable
-import pymssql
-from pymssql import _mssql
 from ..interfaces.cursors import DBCursorBackend
 from ..exceptions import DataError, EmptyStatement, NoDataFound, DriverError, StatementError
 from .sql import SQLDriver, SQLCursor
+
+try:
+    import pymssql
+    from pymssql import _mssql
+except ImportError as _import_err:
+    raise DriverError(
+        "SQL Server driver requires 'pymssql'. "
+        "Install with: pip install asyncdb[msqlserver]"
+    ) from _import_err
 
 
 types_map = {

--- a/asyncdb/drivers/mysqlclient.py
+++ b/asyncdb/drivers/mysqlclient.py
@@ -6,8 +6,6 @@ from typing import Optional, Union, Any
 from collections.abc import Callable, Iterable
 import ssl
 from concurrent.futures import ThreadPoolExecutor
-import MySQLdb
-from MySQLdb.cursors import DictCursor
 from asyncdb.exceptions import (
     ConnectionTimeout,
     NoDataFound,
@@ -16,6 +14,15 @@ from asyncdb.exceptions import (
 from ..interfaces.cursors import DBCursorBackend
 from .base import BasePool
 from .sql import SQLCursor, SQLDriver
+
+try:
+    import MySQLdb
+    from MySQLdb.cursors import DictCursor
+except ImportError as _import_err:
+    raise DriverError(
+        "MySQLdb driver requires 'mysqlclient'. "
+        "Install with: pip install asyncdb[mysql]"
+    ) from _import_err
 
 
 class mysqlCursor(SQLCursor):

--- a/asyncdb/drivers/odbc.py
+++ b/asyncdb/drivers/odbc.py
@@ -6,9 +6,6 @@ from typing import (
     Optional,
 )
 from collections.abc import Iterable
-import aioodbc
-from aioodbc.cursor import Cursor
-import pyodbc
 from ..exceptions import (
     ConnectionTimeout,
     DataError,
@@ -20,6 +17,16 @@ from ..exceptions import (
 )
 from ..interfaces.cursors import DBCursorBackend
 from .sql import SQLDriver, SQLCursor
+
+try:
+    import aioodbc
+    from aioodbc.cursor import Cursor
+    import pyodbc
+except ImportError as _import_err:
+    raise DriverError(
+        "ODBC driver requires 'aioodbc' and 'pyodbc'. "
+        "Install with: pip install asyncdb[odbc]"
+    ) from _import_err
 
 
 class odbcCursor(SQLCursor):

--- a/asyncdb/drivers/outputs/output.py
+++ b/asyncdb/drivers/outputs/output.py
@@ -4,6 +4,14 @@ All Output formats supported by asyncdb.
 
 from importlib import import_module
 
+# Output formats whose module imports optional, non-core dependencies.
+# Used to give an actionable install hint when the format module fails to
+# import, instead of a bare `ImportError` repr.
+_OPTIONAL_FORMAT_EXTRAS: dict = {
+    "arrow": "dataframe",
+    "polars": "dataframe",
+}
+
 
 class OutputFactory:
     _format: dict = {}
@@ -21,6 +29,13 @@ class OutputFactory:
                     obj = getattr(mdl, module_name)
                     cls._format[frmt] = obj
                 except ImportError as e:
+                    extra = _OPTIONAL_FORMAT_EXTRAS.get(frmt)
+                    if extra:
+                        raise RuntimeError(
+                            f"Output format '{frmt}' requires optional "
+                            f"dependencies. Install with: "
+                            f"pip install asyncdb[{extra}]"
+                        ) from e
                     raise RuntimeError(f"Error Loading Output Format {module_name}: {e}") from e
             return cls._format[frmt](*args, **kwargs)
 

--- a/asyncdb/drivers/scylladb.py
+++ b/asyncdb/drivers/scylladb.py
@@ -10,51 +10,57 @@ import logging
 from pathlib import PurePath
 import aiofiles
 import pandas as pd
-
-# async driver:
-import acsylla as c
-
-# Cassandra:
-from cassandra import ReadTimeout
-from cassandra.io.asyncorereactor import AsyncoreConnection
-
-# from cassandra.io.asyncioreactor import AsyncioConnection
-try:
-    from cassandra.io.libevreactor import LibevConnection
-
-    LIBEV = True
-except ImportError:
-    LIBEV = False
-from cassandra.concurrent import execute_concurrent
-from cassandra.policies import (
-    DCAwareRoundRobinPolicy,
-    WhiteListRoundRobinPolicy,
-    DowngradingConsistencyRetryPolicy,
-    ConstantReconnectionPolicy,
-    TokenAwarePolicy,
-    RoundRobinPolicy,
-)
-from cassandra.cluster import Cluster, EXEC_PROFILE_DEFAULT, ExecutionProfile, NoHostAvailable, ResultSet
-from cassandra.query import (
-    tuple_factory,
-    dict_factory,
-    ordered_dict_factory,
-    named_tuple_factory,
-    ConsistencyLevel,
-    PreparedStatement,
-    BatchStatement,
-    SimpleStatement,
-    BatchType,
-)
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.query import SimpleStatement
-from cassandra import ConsistencyLevel
 from .base import InitDriver
 from ..meta.recordset import Recordset
 from ..exceptions import NoDataFound, DriverError
 from ..interfaces.model import ModelBackend
 from ..models import Model
 from ..utils.types import Entity
+
+try:
+    # async driver:
+    import acsylla as c
+
+    # Cassandra:
+    from cassandra import ReadTimeout
+    from cassandra.io.asyncorereactor import AsyncoreConnection
+
+    # from cassandra.io.asyncioreactor import AsyncioConnection
+    try:
+        from cassandra.io.libevreactor import LibevConnection
+
+        LIBEV = True
+    except ImportError:
+        LIBEV = False
+    from cassandra.concurrent import execute_concurrent
+    from cassandra.policies import (
+        DCAwareRoundRobinPolicy,
+        WhiteListRoundRobinPolicy,
+        DowngradingConsistencyRetryPolicy,
+        ConstantReconnectionPolicy,
+        TokenAwarePolicy,
+        RoundRobinPolicy,
+    )
+    from cassandra.cluster import Cluster, EXEC_PROFILE_DEFAULT, ExecutionProfile, NoHostAvailable, ResultSet
+    from cassandra.query import (
+        tuple_factory,
+        dict_factory,
+        ordered_dict_factory,
+        named_tuple_factory,
+        ConsistencyLevel,
+        PreparedStatement,
+        BatchStatement,
+        SimpleStatement,
+        BatchType,
+    )
+    from cassandra.auth import PlainTextAuthProvider
+    from cassandra.query import SimpleStatement
+    from cassandra import ConsistencyLevel
+except ImportError as _import_err:
+    raise DriverError(
+        "ScyllaDB driver requires 'acsylla' and 'cassandra-driver'. "
+        "Install with: pip install asyncdb[scylla]"
+    ) from _import_err
 
 
 logging.getLogger("cassandra").setLevel(logging.INFO)

--- a/asyncdb/drivers/sqlserver.py
+++ b/asyncdb/drivers/sqlserver.py
@@ -4,9 +4,17 @@ import time
 import logging
 from typing import Any, Optional
 from collections.abc import Iterable
-import pymssql
 from ..exceptions import DataError, EmptyStatement, NoDataFound, DriverError
 from .sql import SQLCursor
+
+try:
+    import pymssql
+except ImportError as _import_err:
+    raise DriverError(
+        "SQL Server driver requires 'pymssql'. "
+        "Install with: pip install asyncdb[msqlserver]"
+    ) from _import_err
+
 from .mssql import mssql
 
 

--- a/asyncdb/utils/uv.py
+++ b/asyncdb/utils/uv.py
@@ -1,12 +1,42 @@
 import asyncio
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
 
 
-def install_uvloop():
-    """install uvloop and set as default loop for asyncio."""
+def install_uvloop() -> None:
+    """Install uvloop as the asyncio event loop policy when supported.
+
+    ``uvloop`` only ships wheels for POSIX platforms (Linux, macOS). On
+    unsupported platforms -- most notably Windows -- or when ``uvloop`` is
+    not installed, this function is a safe no-op and the standard asyncio
+    event loop policy remains active. This function is intentionally
+    designed to never raise so it can be safely called as an import-time
+    side effect.
+
+    Returns:
+        None.
+    """
+    if sys.platform.startswith("win"):
+        # uvloop does not support Windows; never attempt to import or
+        # activate it there, keep the standard asyncio policy instead.
+        logger.debug("uvloop is not supported on Windows; skipping activation.")
+        return
     try:
-        import uvloop  # noqa # pylint: disable=import-outside-toplevel
+        import uvloop  # pylint: disable=import-outside-toplevel
 
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         uvloop.install()
     except ImportError:
-        pass
+        logger.debug(
+            "uvloop is not installed; using the default asyncio event loop policy."
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        # Defensive: never let event-loop policy activation break `import
+        # asyncdb` regardless of the underlying platform/runtime cause.
+        logger.debug(
+            "uvloop could not be activated (%s); using the default asyncio "
+            "event loop policy.",
+            exc,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
     "Environment :: Web Environment",
     "License :: OSI Approved :: BSD License",
     "Topic :: Software Development :: Build Tools",

--- a/tests/test_optional_drivers.py
+++ b/tests/test_optional_drivers.py
@@ -1,0 +1,100 @@
+"""Tests for optional/native provider import isolation (FEAT-5 / TASK-24).
+
+These tests verify that:
+
+* A missing optional/native provider dependency does not prevent
+  ``import asyncdb`` or loading an unrelated, already-portable driver.
+* Selecting a provider whose optional/native dependency is unavailable
+  raises a focused ``DriverError`` naming the provider and its installation
+  extra.
+* Genuine (non-``ImportError``) provider import/runtime failures are not
+  indiscriminately rewritten as missing-dependency errors.
+"""
+
+import builtins
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+from asyncdb.exceptions import DriverError
+
+
+def test_core_import_without_unrelated_provider_dependency():
+    """A missing/blocked provider dependency must not prevent `import
+    asyncdb` or loading an unrelated, already-portable driver (dummy) in a
+    fresh interpreter."""
+    script = (
+        "import sys\n"
+        "for name in ('pymssql', 'MySQLdb', 'aioodbc', 'pyodbc', "
+        "'cassandra', 'acsylla'):\n"
+        "    sys.modules[name] = None\n"
+        "import asyncdb\n"
+        "from asyncdb.drivers.dummy import dummy\n"
+        "assert dummy is not None\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "module_path,missing_name,extra_hint",
+    [
+        ("asyncdb.drivers.mssql", "pymssql", "msqlserver"),
+        ("asyncdb.drivers.sqlserver", "pymssql", "msqlserver"),
+        ("asyncdb.drivers.mysqlclient", "MySQLdb", "mysql"),
+        ("asyncdb.drivers.odbc", "aioodbc", "odbc"),
+        ("asyncdb.drivers.cassandra", "cassandra", "cassandra"),
+        ("asyncdb.drivers.scylladb", "acsylla", "scylla"),
+    ],
+)
+def test_selected_provider_missing_extra_has_actionable_error(
+    monkeypatch, module_path, missing_name, extra_hint
+):
+    """Selecting a provider whose native/optional dependency is unavailable
+    raises a focused DriverError naming the provider and install extra."""
+    sys.modules.pop(module_path, None)
+    monkeypatch.setitem(sys.modules, missing_name, None)
+
+    try:
+        with pytest.raises(DriverError) as excinfo:
+            importlib.import_module(module_path)
+
+        message = str(excinfo.value)
+        assert extra_hint in message
+        assert "pip install asyncdb[" in message
+    finally:
+        # Do not leave a half-loaded module cached for later tests.
+        sys.modules.pop(module_path, None)
+
+
+def test_provider_runtime_import_error_is_not_rewritten(monkeypatch):
+    """A non-``ImportError`` raised while a provider module is loading
+    (e.g. a genuine runtime bug) must propagate unmodified and must not be
+    reinterpreted as a missing-dependency DriverError."""
+    module_path = "asyncdb.drivers.mysqlclient"
+    sys.modules.pop(module_path, None)
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "MySQLdb":
+            raise RuntimeError("simulated genuine provider bug")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    try:
+        with pytest.raises(RuntimeError, match="simulated genuine provider bug"):
+            importlib.import_module(module_path)
+    finally:
+        sys.modules.pop(module_path, None)

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,110 @@
+"""Tests for Windows-aligned dependency metadata (FEAT-5 / TASK-25).
+
+These tests validate the `pyproject.toml` dependency/extras boundary
+without importing any provider package: `uvloop` stays an optional extra,
+the approved `default` provider dependencies are declared, and the core
+`dependencies` list is free of the native/optional provider packages
+audited in TASK-24 (which must remain in their explicit extras).
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - repository targets Python >= 3.10
+    import tomli as tomllib
+
+PYPROJECT_PATH = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Native/optional provider packages audited in TASK-24 that must remain in
+# their explicit extras and never leak into the core dependency contract.
+_NATIVE_PROVIDER_PACKAGES = {
+    "pymssql",
+    "mysqlclient",
+    "asyncmy",
+    "aioodbc",
+    "pyodbc",
+    "cassandra-driver",
+    "scylla_driver",
+    "acsylla",
+    "cqlsh",
+    "jpype1",
+    "jaydebeapi",
+    "oracledb",
+    "pylibmc",
+    "uvloop",
+}
+
+
+def _load_pyproject() -> dict[str, Any]:
+    """Load and parse the project's `pyproject.toml`.
+
+    Returns:
+        The parsed TOML document as a dictionary.
+    """
+    with open(PYPROJECT_PATH, "rb") as fh:
+        return tomllib.load(fh)
+
+
+def _package_name(requirement: str) -> str:
+    """Extract the bare (lowercased) package name from a requirement string.
+
+    Args:
+        requirement: A PEP 508-style requirement string, e.g.
+            ``"pymssql==2.3.1"`` or ``"influxdb-client[async]==1.45.0"``.
+
+    Returns:
+        The lowercased package name without version specifiers or extras.
+    """
+    name = requirement.strip()
+    for sep in ("[", "==", ">=", "<=", ">", "<", "~=", "!="):
+        name = name.split(sep, 1)[0]
+    return name.strip().lower()
+
+
+def test_uvloop_is_optional():
+    """`uvloop` must only be declared in its own optional extra, never as a
+    core dependency."""
+    data = _load_pyproject()
+    dependencies = data["project"]["dependencies"]
+    optional = data["project"]["optional-dependencies"]
+
+    core_names = {_package_name(dep) for dep in dependencies}
+    assert "uvloop" not in core_names
+
+    assert "uvloop" in optional
+    uvloop_extra_names = {_package_name(dep) for dep in optional["uvloop"]}
+    assert "uvloop" in uvloop_extra_names
+
+
+def test_default_extra_contains_approved_provider_dependencies():
+    """The `default` extra must declare dependencies for every approved
+    default-scope provider (SQLite, RethinkDB, InfluxDB, SQL Server, Redis,
+    Delta Lake, DuckDB)."""
+    data = _load_pyproject()
+    default_extra = data["project"]["optional-dependencies"]["default"]
+    names = {_package_name(dep) for dep in default_extra}
+
+    expected = {
+        "aiosqlite",
+        "rethinkdb",
+        "influxdb",
+        "influxdb-client",
+        "pymssql",
+        "redis",
+        "deltalake",
+        "duckdb",
+    }
+    assert expected.issubset(names)
+
+
+def test_core_dependency_contract_is_portable():
+    """Core dependencies must not include the native/optional provider
+    packages audited in TASK-24; those remain in explicit extras."""
+    data = _load_pyproject()
+    dependencies = data["project"]["dependencies"]
+    names = {_package_name(dep) for dep in dependencies}
+
+    assert not (names & _NATIVE_PROVIDER_PACKAGES)

--- a/tests/test_release_wheel.py
+++ b/tests/test_release_wheel.py
@@ -1,0 +1,183 @@
+"""Pure wheel archive/tag validation for the release workflow (FEAT-5 / TASK-26).
+
+These helpers mirror the inline validation performed by the "Verify wheel
+tags and compiled Cython extension" step in
+``.github/workflows/release.yml`` and are exercised here against synthetic
+wheel archives, so the tag/extension contract can be regression-tested
+without a real cibuildwheel run and without installing any optional
+dependency.
+"""
+
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+# Supported Windows CPython version tags for the Windows release matrix.
+EXPECTED_WINDOWS_CPYTHON_TAGS = frozenset({"cp310", "cp311", "cp312", "cp313", "cp314"})
+
+
+def parse_wheel_filename(wheel_path: str) -> dict[str, str]:
+    """Parse a wheel filename into its PEP 427 tag components.
+
+    Args:
+        wheel_path: Path (or bare filename) of a ``.whl`` file.
+
+    Returns:
+        A dictionary with ``distribution``, ``version``, ``python_tag``,
+        ``abi_tag`` and ``platform_tag`` keys.
+
+    Raises:
+        ValueError: If the filename does not look like a valid wheel name.
+    """
+    filename = Path(wheel_path).name
+    if not filename.endswith(".whl"):
+        raise ValueError(f"Not a wheel filename: {filename}")
+    stem = filename[: -len(".whl")]
+    parts = stem.split("-")
+    if len(parts) < 5:
+        raise ValueError(f"Not a valid wheel filename: {filename}")
+    python_tag, abi_tag, platform_tag = parts[-3:]
+    version = parts[-4]
+    distribution = "-".join(parts[:-4])
+    return {
+        "distribution": distribution,
+        "version": version,
+        "python_tag": python_tag,
+        "abi_tag": abi_tag,
+        "platform_tag": platform_tag,
+    }
+
+
+def find_compiled_extension(wheel_path: str, suffix: str) -> Optional[str]:
+    """Find the compiled ``asyncdb.utils.types`` extension inside a wheel.
+
+    Args:
+        wheel_path: Path to a ``.whl`` archive.
+        suffix: Expected file suffix, e.g. ``".pyd"`` or ``".so"``.
+
+    Returns:
+        The matching archive member name, or ``None`` if not found.
+    """
+    with zipfile.ZipFile(wheel_path) as archive:
+        for member in archive.namelist():
+            if member.startswith("asyncdb/utils/types.") and member.endswith(suffix):
+                return member
+    return None
+
+
+def assert_wheel_is_valid_for_platform(wheel_path: str) -> str:
+    """Validate a wheel's platform tag and compiled extension.
+
+    A Windows wheel (``platform_tag`` starting with ``win_amd64``) must
+    contain a ``.pyd`` compiled extension. Any other wheel must not use a
+    Windows platform tag and must contain a ``.so`` compiled extension.
+
+    Args:
+        wheel_path: Path to the ``.whl`` archive to validate.
+
+    Returns:
+        The archive member name of the compiled extension that was found.
+
+    Raises:
+        AssertionError: If the tag/extension contract is violated.
+    """
+    tags = parse_wheel_filename(wheel_path)
+    platform_tag = tags["platform_tag"]
+
+    if platform_tag.startswith("win_amd64"):
+        expected_suffix = ".pyd"
+    else:
+        assert not platform_tag.startswith("win"), (
+            f"unexpected Windows platform tag: {platform_tag}"
+        )
+        expected_suffix = ".so"
+
+    ext = find_compiled_extension(wheel_path, expected_suffix)
+    assert ext, (
+        f"compiled Cython extension ({expected_suffix}) missing in {wheel_path}"
+    )
+    return ext
+
+
+def _make_synthetic_wheel(tmp_path: Path, filename: str, extension_member: str) -> Path:
+    """Create a minimal synthetic wheel archive for tag/extension tests.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture value.
+        filename: Wheel filename to create, e.g.
+            ``"asyncdb-2.0.0-cp311-cp311-win_amd64.whl"``.
+        extension_member: Archive member name for the compiled extension,
+            e.g. ``"asyncdb/utils/types.cp311-win_amd64.pyd"``.
+
+    Returns:
+        Path to the created synthetic wheel archive.
+    """
+    wheel_path = tmp_path / filename
+    with zipfile.ZipFile(wheel_path, "w") as archive:
+        archive.writestr(extension_member, b"")
+        archive.writestr("asyncdb/__init__.py", b"")
+    return wheel_path
+
+
+@pytest.fixture()
+def windows_wheel_path(tmp_path: Path) -> Path:
+    """A synthetic, valid Windows (win_amd64/.pyd) wheel archive."""
+    return _make_synthetic_wheel(
+        tmp_path,
+        "asyncdb-2.0.0-cp311-cp311-win_amd64.whl",
+        "asyncdb/utils/types.cp311-win_amd64.pyd",
+    )
+
+
+@pytest.fixture()
+def linux_wheel_path(tmp_path: Path) -> Path:
+    """A synthetic, valid manylinux (.so) wheel archive."""
+    return _make_synthetic_wheel(
+        tmp_path,
+        "asyncdb-2.0.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+        "asyncdb/utils/types.cpython-311-x86_64-linux-gnu.so",
+    )
+
+
+def test_windows_wheel_has_expected_tag_and_extension(windows_wheel_path):
+    """A Windows wheel must report the `win_amd64` tag and contain a
+    `.pyd` compiled extension."""
+    tags = parse_wheel_filename(str(windows_wheel_path))
+    assert tags["platform_tag"] == "win_amd64"
+    assert tags["python_tag"] in EXPECTED_WINDOWS_CPYTHON_TAGS
+
+    member = assert_wheel_is_valid_for_platform(str(windows_wheel_path))
+    assert member.endswith(".pyd")
+
+
+def test_linux_wheel_has_expected_tag_and_extension(linux_wheel_path):
+    """A manylinux wheel must not use a Windows platform tag and must
+    contain a `.so` compiled extension."""
+    member = assert_wheel_is_valid_for_platform(str(linux_wheel_path))
+    assert member.endswith(".so")
+
+
+def test_wheel_missing_compiled_extension_is_rejected(tmp_path):
+    """A wheel missing the compiled extension entirely must fail
+    validation."""
+    wheel_path = tmp_path / "asyncdb-2.0.0-cp311-cp311-win_amd64.whl"
+    with zipfile.ZipFile(wheel_path, "w") as archive:
+        archive.writestr("asyncdb/__init__.py", b"")
+
+    with pytest.raises(AssertionError):
+        assert_wheel_is_valid_for_platform(str(wheel_path))
+
+
+def test_wheel_with_wrong_extension_for_platform_is_rejected(tmp_path):
+    """A Windows-tagged wheel containing a `.so` (not `.pyd`) extension
+    must fail validation."""
+    wheel_path = _make_synthetic_wheel(
+        tmp_path,
+        "asyncdb-2.0.0-cp311-cp311-win_amd64.whl",
+        "asyncdb/utils/types.cpython-311-x86_64-linux-gnu.so",
+    )
+
+    with pytest.raises(AssertionError):
+        assert_wheel_is_valid_for_platform(str(wheel_path))

--- a/tests/test_uvloop.py
+++ b/tests/test_uvloop.py
@@ -1,0 +1,104 @@
+"""Tests for the Windows-safe uvloop activation policy (FEAT-5 / TASK-23).
+
+These tests verify that:
+
+* ``install_uvloop()`` never raises, regardless of platform or whether
+  ``uvloop`` is installed.
+* ``uvloop`` is never imported or activated on Windows.
+* ``uvloop`` activates automatically when it is importable on a supported
+  (non-Windows) platform.
+* The ``AsyncDB``/``AsyncPool``/``asyncdb`` factories keep their dynamic,
+  driver-name-based module lookup behavior.
+"""
+
+import asyncio
+import builtins
+import sys
+
+import pytest
+
+import asyncdb.connections as connections_module
+from asyncdb.connections import AsyncDB, AsyncPool, asyncdb
+from asyncdb.drivers.dummy import dummy
+from asyncdb.utils.uv import install_uvloop
+
+
+def test_install_uvloop_is_noop_when_missing(monkeypatch):
+    """``install_uvloop`` must not raise when ``uvloop`` is not installed."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "uvloop":
+            raise ImportError("No module named 'uvloop'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    # Must not raise.
+    install_uvloop()
+
+
+def test_install_uvloop_skips_windows(monkeypatch):
+    """``install_uvloop`` must not attempt uvloop activation on Windows."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    real_import = builtins.__import__
+    attempted_uvloop_import = False
+
+    def _fake_import(name, *args, **kwargs):
+        nonlocal attempted_uvloop_import
+        if name == "uvloop":
+            attempted_uvloop_import = True
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    previous_policy = asyncio.get_event_loop_policy()
+    install_uvloop()
+
+    assert attempted_uvloop_import is False
+    # The standard asyncio event loop policy remains usable/unchanged.
+    assert isinstance(asyncio.get_event_loop_policy(), type(previous_policy))
+
+
+def test_install_uvloop_activates_when_available_on_supported_platform(monkeypatch):
+    """``uvloop`` activates automatically when present on a supported OS."""
+    uvloop = pytest.importorskip("uvloop")
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    install_uvloop()
+
+    assert isinstance(asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy)
+
+    # Restore the default policy so other tests are not affected.
+    asyncio.set_event_loop_policy(None)
+
+
+def test_asyncdb_factories_keep_dynamic_lookup(monkeypatch):
+    """``AsyncDB``, ``AsyncPool`` and ``asyncdb`` keep resolving
+    ``asyncdb.drivers.<driver>`` dynamically by driver name via
+    ``module_exists``."""
+    instance = AsyncDB("dummy", params={"host": "127.0.0.1", "port": "0", "db": 0})
+    assert isinstance(instance, dummy)
+
+    context_manager = asyncdb(
+        "dummy", params={"host": "127.0.0.1", "port": "0", "db": 0}
+    )
+    assert context_manager is not None
+
+    # AsyncPool resolves "<driver>Pool" from "asyncdb.drivers.<driver>";
+    # verify the dynamic lookup contract without requiring a live backend.
+    calls = []
+
+    def _fake_module_exists(module_name, classpath):
+        calls.append((module_name, classpath))
+        return dummy
+
+    monkeypatch.setattr(connections_module, "module_exists", _fake_module_exists)
+    pool_instance = AsyncPool(
+        "dummy", params={"host": "127.0.0.1", "port": "0", "db": 0}
+    )
+    assert isinstance(pool_instance, dummy)
+    assert calls == [("dummyPool", "asyncdb.drivers.dummy")]

--- a/tests/test_windows_compatibility.py
+++ b/tests/test_windows_compatibility.py
@@ -1,0 +1,160 @@
+"""Core Windows portability regression suite (FEAT-5 / TASK-27).
+
+Assembles the cross-module contracts implemented in TASK-23 (uvloop
+policy), TASK-24 (optional provider import isolation) and TASK-26 (release
+wheel tag/extension validation) into a single regression suite proving:
+
+* The core package imports on a platform without any optional/native
+  provider dependency installed.
+* `uvloop` absence and Windows behavior remain safe.
+* A missing provider dependency does not poison the factory for another,
+  already-portable provider.
+* Release wheels carry the expected platform tag and compiled extension
+  for their platform.
+
+No external database service is required to run this suite.
+"""
+
+import asyncio
+import builtins
+import subprocess
+import sys
+
+import pytest
+
+from asyncdb.connections import AsyncDB
+from asyncdb.drivers.dummy import dummy
+from asyncdb.exceptions import DriverError
+from asyncdb.utils.uv import install_uvloop
+
+from .test_release_wheel import (
+    EXPECTED_WINDOWS_CPYTHON_TAGS,
+    assert_wheel_is_valid_for_platform,
+    parse_wheel_filename,
+)
+from .test_release_wheel import windows_wheel_path  # noqa: F401 (fixture re-export)
+from .test_release_wheel import linux_wheel_path  # noqa: F401 (fixture re-export)
+
+
+# ── Core import isolation ────────────────────────────────────────────────
+
+
+def test_core_wheel_imports_without_optional_dependencies():
+    """`import asyncdb` and loading the portable `dummy` driver must
+    succeed in a fresh interpreter even when every optional/native provider
+    dependency audited in TASK-24 is unavailable."""
+    optional_provider_modules = (
+        "pymssql",
+        "MySQLdb",
+        "aioodbc",
+        "pyodbc",
+        "cassandra",
+        "acsylla",
+        "uvloop",
+    )
+    script = (
+        "import sys\n"
+        f"for name in {optional_provider_modules!r}:\n"
+        "    sys.modules[name] = None\n"
+        "import asyncdb\n"
+        "from asyncdb import AsyncDB\n"
+        "instance = AsyncDB('dummy', params={'host': '127.0.0.1', 'port': '0', 'db': 0})\n"
+        "assert instance is not None\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+# ── uvloop policy ─────────────────────────────────────────────────────────
+
+
+def test_uvloop_absence_does_not_break_core_import(monkeypatch):
+    """`install_uvloop()` must be a safe no-op when `uvloop` cannot be
+    imported, regardless of platform."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "uvloop":
+            raise ImportError("No module named 'uvloop'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    install_uvloop()  # must not raise
+
+
+def test_uvloop_windows_behavior_is_safe(monkeypatch):
+    """On Windows, `install_uvloop()` must never attempt to import uvloop
+    and the standard asyncio event loop policy must remain usable."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    real_import = builtins.__import__
+    attempted = False
+
+    def _fake_import(name, *args, **kwargs):
+        nonlocal attempted
+        if name == "uvloop":
+            attempted = True
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    install_uvloop()
+
+    assert attempted is False
+    # The standard asyncio policy must still be able to create a loop.
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+    try:
+        assert loop is not None
+    finally:
+        loop.close()
+
+
+# ── Provider isolation at the factory level ──────────────────────────────
+
+
+def test_portable_provider_factory_survives_missing_provider(monkeypatch):
+    """Selecting a provider whose native dependency is missing must raise a
+    focused `DriverError` without preventing a subsequent, unrelated
+    portable provider (`dummy`) from loading successfully."""
+    sys.modules.pop("asyncdb.drivers.sqlserver", None)
+    monkeypatch.setitem(sys.modules, "pymssql", None)
+
+    with pytest.raises(DriverError):
+        AsyncDB("sqlserver", params={"host": "127.0.0.1", "port": "0", "db": 0})
+
+    sys.modules.pop("asyncdb.drivers.sqlserver", None)
+
+    # The portable "dummy" driver must still load without issue.
+    instance = AsyncDB("dummy", params={"host": "127.0.0.1", "port": "0", "db": 0})
+    assert isinstance(instance, dummy)
+
+
+# ── Release wheel tag/extension checks ───────────────────────────────────
+
+
+def test_wheel_extension_matches_platform(windows_wheel_path, linux_wheel_path):
+    """Each wheel's compiled extension must match its own platform tag."""
+    windows_member = assert_wheel_is_valid_for_platform(str(windows_wheel_path))
+    assert windows_member.endswith(".pyd")
+
+    linux_member = assert_wheel_is_valid_for_platform(str(linux_wheel_path))
+    assert linux_member.endswith(".so")
+
+
+def test_supported_windows_tag(windows_wheel_path):
+    """A Windows release wheel must use a supported CPython tag and the
+    `win_amd64` platform tag."""
+    tags = parse_wheel_filename(str(windows_wheel_path))
+    assert tags["platform_tag"] == "win_amd64"
+    assert tags["python_tag"] in EXPECTED_WINDOWS_CPYTHON_TAGS


### PR DESCRIPTION
## Summary

Makes asyncdb's core import path and default driver set safe on Windows, without claiming universal provider support.

- **TASK-23** — Made core import and uvloop activation Windows-safe: `install_uvloop()` now no-ops on Windows (checked via `sys.platform`) and never raises during `import asyncdb`; automatic activation preserved on supported platforms. Factory signatures (`AsyncDB`, `AsyncPool`, `asyncdb`) unchanged.
- **TASK-24** — Deferred/guarded optional native provider imports (`mssql`, `sqlserver`, `mysqlclient`, `odbc`, `cassandra`, `scylladb`) so a missing native dependency raises an actionable `DriverError` (with the matching `pip install asyncdb[<extra>]` hint) instead of poisoning `import asyncdb`. Also improved `OutputFactory`'s error message for the `arrow`/`polars` (dataframe extra) formats.
- **TASK-25** — Audited `pyproject.toml` dependency classification against the TASK-24 import audit (no core dependency needed reclassification — already portable); added Windows/macOS trove classifiers and documented the Windows support boundary in `README.md`.
- **TASK-26** — Strengthened the release workflow's wheel verification step to assert `win_amd64` tag + `.pyd` extension on Windows (and `.so` + non-`win*` tag elsewhere), and that wheels exist for all of CPython 3.10–3.14 on Windows.
- **TASK-27** — Added a cross-module Windows portability regression suite: subprocess-isolated core-import test with all optional/native providers blocked, uvloop policy regression tests, provider-isolation test, and wheel tag/extension tests.

## Tasks

5/5 tasks verified (commits found + all listed files present in the worktree).

- ✅ TASK-23 — Make Core Import and uvloop Policy Windows-Safe
- ✅ TASK-24 — Defer Optional Provider Imports
- ✅ TASK-25 — Align Dependency Metadata with Windows Support
- ✅ TASK-26 — Request and Validate Windows Release Wheels
- ✅ TASK-27 — Add Core Windows Portability Tests

25 new tests added across `tests/test_uvloop.py`, `tests/test_optional_drivers.py`, `tests/test_package_metadata.py`, `tests/test_release_wheel.py`, `tests/test_windows_compatibility.py`; full repository test collection (375 tests) still succeeds with no collection errors.

Two pre-existing, unrelated issues were identified but left untouched (out of scope, reproduced on unmodified files): a `Recordset` import bug in `asyncdb/drivers/cassandra.py`, and a missing local `libodbc.so.2` (unixODBC) system library affecting `asyncdb/drivers/odbc.py` in this dev environment.

---
_Closed by /sdd-done_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TksYGMhs33kgte1sSeKGXd

## Summary by Sourcery

Make AsyncDB core imports and default usage Windows-safe while isolating unsupported optional providers and validating compatible release wheels.

New Features:
- Add documented Windows support for the core package and default driver extra across Python 3.10–3.14.
- Provide actionable errors when selected optional or native providers are unavailable. 

Bug Fixes:
- Prevent Windows or unavailable uvloop installations from breaking core imports.
- Prevent missing optional provider dependencies from poisoning unrelated AsyncDB imports and factory usage.

Enhancements:
- Harden wheel validation for platform tags and compiled extension formats across Windows and Unix builds.
- Clarify platform and provider support boundaries in the README and package metadata.

CI:
- Strengthen release checks to require win_amd64 wheels with .pyd extensions for CPython 3.10–3.14 on Windows while retaining .so validation elsewhere.

Documentation:
- Document core, default-extra, uvloop, and optional-provider platform support boundaries.

Tests:
- Add regression coverage for safe uvloop behavior, optional provider isolation, dependency metadata, wheel tags/extensions, and Windows-compatible core imports.

Chores:
- Add the Windows compatibility specification, task tracking, and reusable task template documentation.